### PR TITLE
feat: add some swiss planes

### DIFF
--- a/input/avions.csv
+++ b/input/avions.csv
@@ -33,3 +33,6 @@ F-HGSA,399A40,avion de location Valljet,17/08/2020,Embraer Legacy 600,EMB-135BJ,
 F-HJMA,39A580,avion de location Valljet,21/03/2019,Embraer Legacy 600,EMB-135BJ,14500854,312,3042,2022-09-13,non
 F-HSTB,39CA61,avion de location Valljet,11/03/2020,Embraer Legacy 650,EMB-135BJ,14501160,403,3530,2022-09-13,non
 F-HBAN,39840D,avion de location Valljet,12/07/2022,Embraer Legacy 650,EMB-135BJ,14501141,403,3530,2022-09-13,non
+HB-JFX,4B185D,avion #1 du groupe Rolex,28/06/2017,Bombardier Global 6000,BD-700-1A10,9500,480,4700,2022-09-13,non
+HB-JLF,4B18E7,avion #2 du groupe Rolex,16/12/2020,Bombardier Global 6000,BD-700-2A12,9748,480,4700,2022-09-13,non
+F-HMBY,39b038,avion du groupe Crédit Suisse,23/08/2021,Bombardier Global 6000,BD-700-2A12,9748,480,4700,2022-09-13,non


### PR DESCRIPTION
Le registre de l'aviation civile suisse est accessible ici : https://app02.bazl.admin.ch/web/bazl/en/#/lfr/search